### PR TITLE
Properly added RN Gesture Handler to Android

### DIFF
--- a/android/app/src/main/java/com/allthingsstarwars/MainActivity.java
+++ b/android/app/src/main/java/com/allthingsstarwars/MainActivity.java
@@ -1,15 +1,27 @@
 package com.allthingsstarwars;
 
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 
 public class MainActivity extends ReactActivity {
+    /**
+     * Returns the name of the main component registered from JavaScript. This is used to schedule
+     * rendering of the component.
+     */
+    @Override
+    protected String getMainComponentName() {
+        return "AllThingsStarWars";
+    }
 
-  /**
-   * Returns the name of the main component registered from JavaScript. This is used to schedule
-   * rendering of the component.
-   */
-  @Override
-  protected String getMainComponentName() {
-    return "AllThingsStarWars";
-  }
+    @Override
+    protected ReactActivityDelegate createReactActivityDelegate() {
+        return new ReactActivityDelegate(this, getMainComponentName()) {
+            @Override
+            protected ReactRootView createRootView() {
+              return new RNGestureHandlerEnabledRootView(MainActivity.this);
+            }
+        };
+    }
 }


### PR DESCRIPTION
When adding `react-native-gesture-handler`, Android was not properly configured to use the library.